### PR TITLE
Fix the weekday 'Unknowns' bug

### DIFF
--- a/CatchUp-SwiftUI.xcodeproj/project.pbxproj
+++ b/CatchUp-SwiftUI.xcodeproj/project.pbxproj
@@ -504,7 +504,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tokensolutions.CatchUp;
 				PRODUCT_NAME = CatchUp;
 				SUPPORTS_MACCATALYST = NO;
@@ -532,7 +532,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tokensolutions.CatchUp;
 				PRODUCT_NAME = CatchUp;
 				SUPPORTS_MACCATALYST = NO;

--- a/CatchUp-SwiftUI/Data/SelectedContact.swift
+++ b/CatchUp-SwiftUI/Data/SelectedContact.swift
@@ -28,7 +28,7 @@ class SelectedContact {
     var notification_preference_hour: Int = 0
     var notification_preference_minute: Int = 0
     var notification_preference_quarterly_set_time: Date = Date()
-    var notification_preference_weekday: Int = 0
+    var notification_preference_weekday: Int = 1
     var notification_preference_week_of_month: Int = 0
     var phone: String = ""
     var picture: String = ""
@@ -118,6 +118,46 @@ class SelectedContact {
 
     func preferenceIsCustom() -> Bool {
         notification_preference == 6
+    }
+
+    func hasPhone() -> Bool {
+        phone != "" ? true : false
+    }
+
+    func hasSecondaryPhone() -> Bool {
+        secondary_phone != "" ? true : false
+    }
+
+    func hasEmail() -> Bool {
+        email != "" ? true : false
+    }
+
+    func hasSecondaryEmail() -> Bool {
+        secondary_email != "" ? true : false
+    }
+
+    func hasAddress() -> Bool {
+        address != "" ? true : false
+    }
+
+    func hasSecondaryAddress() -> Bool {
+        secondary_address != "" ? true : false
+    }
+
+    func hasBirthday() -> Bool {
+        birthday != "" ? true : false
+    }
+
+    func hasAnniversary() -> Bool {
+        anniversary != "" ? true : false
+    }
+
+    func hasContactInfo() -> Bool {
+        if hasPhone() || hasSecondaryPhone() || hasEmail() || hasSecondaryEmail() || hasAddress() || hasSecondaryAddress() || hasBirthday() || hasAnniversary() {
+            return true
+        } else {
+            return false
+        }
     }
 
     static let sampleData = SelectedContact(

--- a/CatchUp-SwiftUI/Utilities/ContactHelper.swift
+++ b/CatchUp-SwiftUI/Utilities/ContactHelper.swift
@@ -11,43 +11,8 @@ import UIKit
 import Contacts
 import CoreData
 
+// Functions for creating and updating a contact
 struct ContactHelper {
-    // MARK: Functions for DetailScreen
-    
-    static func contactHasPhone(_ contact: SelectedContact) -> Bool {
-        return contact.phone != "" ? true : false
-    }
-    
-    static func contactHasSecondaryPhone(_ contact: SelectedContact) -> Bool {
-        return contact.secondary_phone != "" ? true : false
-    }
-    
-    static func contactHasEmail(_ contact: SelectedContact) -> Bool {
-        return contact.email != "" ? true : false
-    }
-    
-    static func contactHasSecondaryEmail(_ contact: SelectedContact) -> Bool {
-        return contact.secondary_email != "" ? true : false
-    }
-    
-    static func contactHasAddress(_ contact: SelectedContact) -> Bool {
-        return contact.address != "" ? true : false
-    }
-    
-    static func contactHasSecondaryAddress(_ contact: SelectedContact) -> Bool {
-        return contact.secondary_address != "" ? true : false
-    }
-
-    static func contactHasBirthday(_ contact: SelectedContact) -> Bool {
-        return contact.birthday != "" ? true : false
-    }
-
-    static func contactHasAnniversary(_ contact: SelectedContact) -> Bool {
-        return contact.anniversary != "" ? true : false
-    }
-
-    // MARK: Functions for ContactPickerViewController
-    
     static func encodeContactPicture(for contact: CNContact) -> String {
 		let picture: String
 		
@@ -283,7 +248,7 @@ struct ContactHelper {
         let notification_preference_hour = currentHour
         let notification_preference_minute = currentMinute
         let notification_preference_quarterly_set_time = Date()
-        let notification_preference_weekday = 0
+        let notification_preference_weekday = 1
         let notification_preference_custom_year = currentYear
         let notification_preference_custom_month = currentMonth
         let notification_preference_custom_day = currentDay

--- a/CatchUp-SwiftUI/Utilities/NotificationHelper.swift
+++ b/CatchUp-SwiftUI/Utilities/NotificationHelper.swift
@@ -21,11 +21,11 @@ struct NotificationHelper {
                 addGeneralNotification(for: contact)
             }
             
-            if ContactHelper.contactHasBirthday(contact) {
+            if contact.hasBirthday() {
                 addBirthdayNotification(for: contact)
             }
             
-            if ContactHelper.contactHasAnniversary(contact) {
+            if contact.hasAnniversary() {
                 addAnniversaryNotification(for: contact)
             }
         }
@@ -128,14 +128,14 @@ struct NotificationHelper {
             soonestUpcomingNotificationDateString = calculateDateStringFromComponents(components)
         }
 
-        if ContactHelper.contactHasBirthday(contact) && !contact.preferenceIsNever() {
+        if contact.hasBirthday() && !contact.preferenceIsNever() {
             let birthdayDateString = calculateDateStringFromComponents(getBirthdayDateComponents(for: contact))
             if birthdayDateString < soonestUpcomingNotificationDateString {
                 soonestUpcomingNotificationDateString = birthdayDateString
             }
         }
 
-        if ContactHelper.contactHasAnniversary(contact) && !contact.preferenceIsNever() {
+        if contact.hasAnniversary() && !contact.preferenceIsNever() {
             let anniversaryDateString = calculateDateStringFromComponents(getAnniversaryDateComponents(for: contact))
             if anniversaryDateString < soonestUpcomingNotificationDateString {
                 soonestUpcomingNotificationDateString = anniversaryDateString
@@ -339,11 +339,11 @@ struct NotificationHelper {
     static func removeExistingNotifications(for contact: SelectedContact) {
         removeGeneralNotification(for: contact)
         
-        if ContactHelper.contactHasBirthday(contact) {
+        if contact.hasBirthday() {
             removeBirthdayNotification(for: contact)
         }
         
-        if ContactHelper.contactHasAnniversary(contact) {
+        if contact.hasAnniversary() {
             removeAnniversaryNotification(for: contact)
         }
     }

--- a/CatchUp-SwiftUI/Views/DetailScreen Subviews/BirthdayOrAnniversaryRow.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen Subviews/BirthdayOrAnniversaryRow.swift
@@ -37,7 +37,7 @@ struct BirthdayOrAnniversaryRow: View {
     }
 
     func dayBeforeAnniversaryString() -> String? {
-        if ContactHelper.contactHasAnniversary(contact) {
+        if contact.hasAnniversary() {
             return NotificationHelper.calculateDateStringFromComponents(NotificationHelper.getAnniversaryDateComponents(for: contact))
         }
         

--- a/CatchUp-SwiftUI/Views/DetailScreen Subviews/ContactInfoView.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen Subviews/ContactInfoView.swift
@@ -41,7 +41,7 @@ struct ContactInfoView: View {
     }
 
     var body: some View {
-        if ContactHelper.contactHasPhone(contact) {
+        if contact.hasPhone() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Phone")
                     .font(.caption)
@@ -52,7 +52,8 @@ struct ContactInfoView: View {
                 .foregroundStyle(.blue)
             }
         }
-        if ContactHelper.contactHasSecondaryPhone(contact) {
+
+        if contact.hasSecondaryPhone() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Secondary Phone")
                     .font(.caption)
@@ -63,7 +64,8 @@ struct ContactInfoView: View {
                 .foregroundStyle(.blue)
             }
         }
-        if ContactHelper.contactHasEmail(contact) {
+
+        if contact.hasEmail() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Email")
                     .font(.caption)
@@ -86,7 +88,8 @@ struct ContactInfoView: View {
                 Button("Cancel", role: .cancel) {}
             }
         }
-        if ContactHelper.contactHasSecondaryEmail(contact) {
+
+        if contact.hasSecondaryEmail() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Secondary Email")
                     .font(.caption)
@@ -99,7 +102,8 @@ struct ContactInfoView: View {
                 .foregroundStyle(.blue)
             }
         }
-        if ContactHelper.contactHasAddress(contact) {
+
+        if contact.hasAddress() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Address")
                     .font(.caption)
@@ -109,7 +113,8 @@ struct ContactInfoView: View {
                 .foregroundStyle(.blue)
             }
         }
-        if ContactHelper.contactHasSecondaryAddress(contact) {
+
+        if contact.hasSecondaryAddress() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Secondary Address")
                     .font(.caption)
@@ -119,7 +124,8 @@ struct ContactInfoView: View {
                 .foregroundStyle(.blue)
             }
         }
-        if ContactHelper.contactHasBirthday(contact) {
+
+        if contact.hasBirthday() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Birthday")
                     .font(.caption)
@@ -133,7 +139,8 @@ struct ContactInfoView: View {
                 }
             }
         }
-        if ContactHelper.contactHasAnniversary(contact) {
+        
+        if contact.hasAnniversary() {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Anniversary")
                     .font(.caption)

--- a/CatchUp-SwiftUI/Views/DetailScreen Subviews/NotificationPreferenceView.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen Subviews/NotificationPreferenceView.swift
@@ -12,8 +12,8 @@ struct NotificationPreferenceView: View {
     @Environment(DataController.self) var dataController
     @Environment(\.modelContext) var modelContext
 
-    @State private var initialNotificationPreference = 0
-    @State private var initialNotificationPreferenceWeekday = 0
+    @State private var initialNotificationPreference = 0 // Never
+    @State private var initialNotificationPreferenceWeekday = 1 // Sunday
     @State private var initialNotificationPreferenceTime = Date()
     @State private var initialNotificationPreferenceCustomDate = Date()
 

--- a/CatchUp-SwiftUI/Views/DetailScreen.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen.swift
@@ -37,8 +37,11 @@ struct DetailScreen: View {
                 Section("Notification Preference") {
                     NotificationPreferenceView(contact: contact)
                 }
-                Section("Contact Information") {
-                    ContactInfoView(contact: contact)
+
+                if contact.hasContactInfo() {
+                    Section("Contact Information") {
+                        ContactInfoView(contact: contact)
+                    }
                 }
 
                 RemoveContactButton(contact: contact)

--- a/CatchUp-SwiftUI/Views/HomeScreen.swift
+++ b/CatchUp-SwiftUI/Views/HomeScreen.swift
@@ -61,6 +61,7 @@ struct HomeScreen : View {
                     }
                 } else {
                     Text("No CatchUps yet! Tap the 'Add Contacts' button to add some.")
+                        .foregroundStyle(.gray)
                 }
             }
             .refreshable {


### PR DESCRIPTION
- Default `weekday` to 1 (Sunday) instead of 0 (Unknown) when adding a contact
- Only show the 'Contact Info' section on the detail screen if there is actually any contact info
- Change the 'No CatchUps yet' text to gray
- Code cleanup