### PR TITLE
Preserve the Country Code in Phone Numbers

### DIFF
--- a/CatchUp-SwiftUI.xcodeproj/project.pbxproj
+++ b/CatchUp-SwiftUI.xcodeproj/project.pbxproj
@@ -504,7 +504,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.2;
+				MARKETING_VERSION = 3.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tokensolutions.CatchUp;
 				PRODUCT_NAME = CatchUp;
 				SUPPORTS_MACCATALYST = NO;
@@ -532,7 +532,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.2;
+				MARKETING_VERSION = 3.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tokensolutions.CatchUp;
 				PRODUCT_NAME = CatchUp;
 				SUPPORTS_MACCATALYST = NO;

--- a/CatchUp-SwiftUI/Utilities/ContactHelper.swift
+++ b/CatchUp-SwiftUI/Utilities/ContactHelper.swift
@@ -168,27 +168,19 @@ struct ContactHelper {
 		var anniversaryString: String
 		
 		let anniversary = contact.dates.filter { date -> Bool in
-			
 			guard let label = date.label else {
 				return false
 			}
-			
 			return label.contains("Anniversary")
-			
-			} .first?.value as DateComponents?
+        } .first?.value as DateComponents?
 		
-		if anniversary?.date != nil {
-			
+        if let anniversaryDate = anniversary?.date {
 			let formatter = DateFormatter()
 			formatter.dateFormat = "MM-dd"
 			formatter.locale = Locale(identifier: "en_US_POSIX")
 			formatter.timeZone = TimeZone(secondsFromGMT: 0)
-			
-			anniversaryString = formatter.string(from: (anniversary?.date!)!)
-			
-			let anniversaryDate = formatter.date(from: anniversaryString)!
+
 			anniversaryString = formatter.string(from: anniversaryDate)
-			
 		} else {
 			anniversaryString = ""
 		}

--- a/CatchUp-SwiftUI/Utilities/Conversions.swift
+++ b/CatchUp-SwiftUI/Utilities/Conversions.swift
@@ -12,31 +12,31 @@ import PhoneNumberKit
 
 struct Converter {
     // MARK: Only used in DetailScreen
-    static func getFormattedPhoneNumber(from phoneNumber: String) -> String {
-        let phoneNumberKit = PhoneNumberKit()
-
+    static func getFormattedPhoneNumber(from phoneNumber: String, with phoneNumberKit: PhoneNumberKit) -> String {
         print("formatting phone number: \(phoneNumber)")
 
         do {
             let parsedPhoneNumber = try phoneNumberKit.parse(phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines))
-            let formattedPhoneNumber = phoneNumberKit.format(parsedPhoneNumber, toType: .national)
+            let formattedPhoneNumber = phoneNumberKit.format(parsedPhoneNumber, toType: .international)
             return formattedPhoneNumber
-        }
-        catch {
-            print("PhoneNumberKit Parse Error: \(error)")
+        } catch {
+            print("PhoneNumberKit parse error: \(error)")
             return phoneNumber
         }
     }
     
-    static func getTappablePhoneNumber(from phoneNumber: String) -> URL {
+    static func getTappablePhoneNumber(from phoneNumber: String) -> URL? {
         print("getting tappable phone number: \(phoneNumber)")
 
         let tel = "tel://"
         let cleanNumber = phoneNumber.replacingOccurrences(of: "[^\\d+]", with: "", options: [.regularExpression])
         let formattedString = tel + cleanNumber
-        let tappableNumber = URL(string: formattedString)!
-        
-        return tappableNumber
+
+        if let tappableNumber = URL(string: formattedString) {
+            return tappableNumber
+        } else {
+            return nil
+        }
     }
     
     static func getTappableEmail(from emailAddress: String) -> URL {
@@ -97,14 +97,21 @@ struct Converter {
     }
     
     
-    // MARK: Used in HomeScreen and DetailScreen
-    
+    // MARK: Used in ContactPictureView and DetailScreen
+
     static func getContactPicture(from string: String) -> Image {
-        let imageData = NSData(base64Encoded: string)
-        let uiImage = UIImage(data: imageData! as Data)!
-        let image = Image(uiImage: uiImage)
-        
-        return image
+        if let imageData = NSData(base64Encoded: string) {
+            if let uiImage = UIImage(data: imageData as Data) {
+                let image = Image(uiImage: uiImage)
+                return image
+            } else {
+                let image = Image(uiImage: UIImage(named: "DefaultPhoto")!)
+                return image
+            }
+        } else {
+            let image = Image(uiImage: UIImage(named: "DefaultPhoto")!)
+            return image
+        }
     }
 	
     static func convertNotificationPreferenceToString(contact: SelectedContact) -> String {
@@ -324,10 +331,10 @@ struct Converter {
 		dateComponents.day = Int(contact.notification_preference_custom_day)
 		dateComponents.year = Int(contact.notification_preference_custom_year)
 		
-		let dateTime = Calendar.current.date(from: dateComponents)
-		let dateString = formatter.string(from: dateTime!)
-		let dayDate = formatter.date(from: dateString)!
-		
+        guard let dateTime = Calendar.current.date(from: dateComponents) else { return "Unknown" }
+        let dateString = formatter.string(from: dateTime)
+        guard let dayDate = formatter.date(from: dateString) else { return "Unknown" }
+
 		day = formatter.string(from: dayDate)
 		year = String(contact.notification_preference_custom_year)
 		

--- a/CatchUp-SwiftUI/Views/DetailScreen Subviews/ContactInfoView.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen Subviews/ContactInfoView.swift
@@ -7,28 +7,31 @@
 //
 
 import MapKit
+import PhoneNumberKit
 import SwiftUI
 
 struct ContactInfoView: View {
     @State private var isShowingEmailAlert = false
     @State private var emailString = ""
     @State private var emailUrlForAlert: URL?
+    @State private var isShowingInvalidPhoneNumberAlert = false
 
+    let phoneNumberKit = PhoneNumberKit()
     let contact: SelectedContact
 
     var formattedPrimaryPhoneNumber: String {
-        Converter.getFormattedPhoneNumber(from: contact.phone)
+        Converter.getFormattedPhoneNumber(from: contact.phone, with: phoneNumberKit)
     }
 
     var formattedSecondaryPhoneNumber: String {
-        Converter.getFormattedPhoneNumber(from: contact.secondary_phone)
+        Converter.getFormattedPhoneNumber(from: contact.secondary_phone, with: phoneNumberKit)
     }
 
-    var tappablePrimaryPhoneNumber: URL {
+    var tappablePrimaryPhoneNumber: URL? {
         Converter.getTappablePhoneNumber(from: contact.phone)
     }
 
-    var tappableSecondaryPhoneNumber: URL {
+    var tappableSecondaryPhoneNumber: URL? {
         Converter.getTappablePhoneNumber(from: contact.secondary_phone)
     }
 
@@ -47,10 +50,19 @@ struct ContactInfoView: View {
                     .font(.caption)
 
                 Button(formattedPrimaryPhoneNumber) {
-                    UIApplication.shared.open(tappablePrimaryPhoneNumber)
+                    if let tappablePrimaryPhoneNumber {
+                        UIApplication.shared.open(tappablePrimaryPhoneNumber)
+                    } else {
+                        isShowingInvalidPhoneNumberAlert = true
+                    }
                 }
                 .foregroundStyle(.blue)
             }
+            .alert("Phone number is invalid", isPresented: $isShowingInvalidPhoneNumberAlert, actions: {
+                Button("OK", role: .cancel) {}
+            }, message: {
+                Text("Could not dial this phone number. Ensure the number is correct in your Contacts app.")
+            })
         }
 
         if contact.hasSecondaryPhone() {
@@ -59,7 +71,11 @@ struct ContactInfoView: View {
                     .font(.caption)
 
                 Button(formattedSecondaryPhoneNumber) {
-                    UIApplication.shared.open(tappableSecondaryPhoneNumber)
+                    if let tappableSecondaryPhoneNumber {
+                        UIApplication.shared.open(tappableSecondaryPhoneNumber)
+                    } else {
+                        isShowingInvalidPhoneNumberAlert = true
+                    }
                 }
                 .foregroundStyle(.blue)
             }

--- a/CatchUp-SwiftUI/Views/DetailScreen Subviews/NotificationPreferenceView.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen Subviews/NotificationPreferenceView.swift
@@ -23,6 +23,7 @@ struct NotificationPreferenceView: View {
     @State private var whatDayText = ""
 
     @Bindable var contact: SelectedContact
+    @Binding var shouldSetPreferenceViewState: Bool
 
     let notificationOptions: [NotificationOption] = NotificationOption.allCases
     let dayOptions: [DayOption] = DayOption.allCases
@@ -82,7 +83,10 @@ struct NotificationPreferenceView: View {
             }
         }
         .onAppear {
-            setInitialState()
+            if shouldSetPreferenceViewState {
+                shouldSetPreferenceViewState = false
+                setInitialState()
+            }
         }
 
         .onChange(of: contact) {
@@ -211,5 +215,5 @@ struct NotificationPreferenceView: View {
 }
 
 #Preview {
-    NotificationPreferenceView(contact: SelectedContact.sampleData)
+    NotificationPreferenceView(contact: SelectedContact.sampleData, shouldSetPreferenceViewState: .constant(true))
 }

--- a/CatchUp-SwiftUI/Views/DetailScreen.swift
+++ b/CatchUp-SwiftUI/Views/DetailScreen.swift
@@ -12,6 +12,8 @@ struct DetailScreen: View {
     @Environment(DataController.self) var dataController
     @Bindable var contact: SelectedContact
 
+    @State private var shouldSetPreferenceViewState = true
+
     var nextCatchUpTime: String {
         print("recalculating nextCatchUpTime")
         return ContactHelper.getFriendlyNextCatchUpTime(for: contact, forQuarterlyPreference: false)
@@ -35,7 +37,7 @@ struct DetailScreen: View {
                     BirthdayOrAnniversaryRow(contact: contact)
                 }
                 Section("Notification Preference") {
-                    NotificationPreferenceView(contact: contact)
+                    NotificationPreferenceView(contact: contact, shouldSetPreferenceViewState: $shouldSetPreferenceViewState)
                 }
 
                 if contact.hasContactInfo() {


### PR DESCRIPTION
- We were using `PhoneNumberKit`'s `.national` config when formatting phone numbers. This got rid of the country codes and hindered international calling. We now use the `.international` config to resolve this
- Little bits of code cleanup