### PR TITLE
v3.2.0 continued

### DIFF
--- a/CatchUp-SwiftUI/Views/HomeScreen.swift
+++ b/CatchUp-SwiftUI/Views/HomeScreen.swift
@@ -67,6 +67,9 @@ struct HomeScreen : View {
                 await NotificationHelper.resetNotifications(for: selectedContacts, delayTime: 0)
                 await ContactHelper.updateSelectedContacts(selectedContacts)
             }
+			.safeAreaInset(edge: .bottom) {
+				Color.clear.frame(height: 40)
+			}
             .onChange(of: contactPicker.chosenContact) {
                 if let contact = contactPicker.chosenContact {
                     saveSelectedContact(for: [contact])


### PR DESCRIPTION
Add some extra safe area beneath the list so the 'add contacts' button doesn't overlap with the last list row when scrolled all the way down