### PR TITLE
v3.2.3

### DIFF
--- a/CatchUp-SwiftUI.xcodeproj/project.pbxproj
+++ b/CatchUp-SwiftUI.xcodeproj/project.pbxproj
@@ -292,7 +292,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.2;
+				MARKETING_VERSION = 3.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tokensolutions.CatchUp;
 				PRODUCT_NAME = CatchUp;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -326,7 +326,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.2;
+				MARKETING_VERSION = 3.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tokensolutions.CatchUp;
 				PRODUCT_NAME = CatchUp;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/CatchUp-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CatchUp-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/marmelroy/PhoneNumberKit.git",
       "state" : {
-        "revision" : "6f736377e2353040a48fdc39d93385c4108c8dce",
-        "version" : "4.1.9"
+        "revision" : "2d547ffe38f61009219e34e5378d2aa4c13b6e51",
+        "version" : "4.2.12"
       }
     }
   ],


### PR DESCRIPTION
App Store Optimizations:
- Change app name from "CatchUp - Keep in Touch" to "CatchUp: Keep in Touch"
- Change app subtitle from "Remember to stay in touch" to "Personal relationship manager"
- Update keywords

Update `PhoneNumberKit` to latest so that there's a code change I can submit a new build with